### PR TITLE
Disable now bot comments on Github

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
By default the Zeit Now comments on pull requests and commits after
deployments. This is unnecessarily noisy. Github already has a mechanism
for showing deployments of pull requests.

Reference:

https://zeit.co/docs/v2/advanced/now-for-github#disable-commenting-with-silent-mode